### PR TITLE
Address array shape incompatbility with new pyuvsim and UVBeam future_array_shapes

### DIFF
--- a/hydra/beam_sampler.py
+++ b/hydra/beam_sampler.py
@@ -6,7 +6,6 @@ from matplotlib.colors import SymLogNorm
 
 from pyuvsim import AnalyticBeam
 from pyuvsim.analyticbeam import diameter_to_sigma
-from pyuvdata import 
 from vis_cpu import conversions
 
 from .vis_simulator import simulate_vis_per_source

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -2,6 +2,7 @@
 import numpy as np
 from vis_cpu import conversions
 import pyuvdata
+from pyuvsim import AnalyticBeam
 
 
 def flatten_vector(v):
@@ -412,3 +413,21 @@ def antenna_dict_from_uvd(uvd):
     for i, ant in enumerate(ant_ids):
         ants[ant] = enu[i]
     return ants
+
+
+def get_beam_interp_shape(beam):
+    """
+    Determine whether the spw axis is present.
+
+    Parameters:
+        beam (AnalyticBeam or UVBeam)
+    """
+    # Check beam type to see shape for return of interp method
+    if isinstance(beam, AnalyticBeam):
+        spw_axis_present = False
+    elif isinstance(beam, pyuvdata.UVBeam):
+        spw_axis_present = not beam.future_array_shapes
+    else:
+        raise ValueError("beam object is not AnalyticBeam or UVBeam object.")
+
+    return spw_axis_present

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -417,14 +417,18 @@ def antenna_dict_from_uvd(uvd):
 
 def get_beam_interp_shape(beam):
     """
-    Determine whether the spw axis is present.
+    Determine whether the spw axis is present in a beam object.
 
     Parameters:
-        beam (AnalyticBeam or UVBeam)
+        beam (AnalyticBeam or UVBeam): The beam object in question. Must be an
+            instance of either AnalyticBeam or UVBeam.
+    Returns:
+        spw_axis_present (bool): Whether the spw axis is present.
     """
     # Check beam type to see shape for return of interp method
     if isinstance(beam, AnalyticBeam):
         spw_axis_present = False
+
     elif isinstance(beam, pyuvdata.UVBeam):
         spw_axis_present = not beam.future_array_shapes
     else:

--- a/hydra/vis_simulator.py
+++ b/hydra/vis_simulator.py
@@ -232,6 +232,7 @@ def vis_sim_per_source(
         # Primary beam pattern using direct interpolation of UVBeam object
         az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
         for i, bm in enumerate(beam_list):
+            spw_axis_present = utils.get_beam_interp_shape(bm)
             kw = (
                 {"reuse_spline": True, "check_azza_domain": False}
                 if isinstance(bm, UVBeam)
@@ -243,11 +244,17 @@ def vis_sim_per_source(
             )[0]
 
             if polarized:
-                interp_beam = interp_beam[:, 0, :, 0, :]
+                if spw_axis_present:
+                    interp_beam = interp_beam[:, 0, :, 0, :]
+                else:
+                    interp_beam = interp_beam[:, :, 0, :]
             else:
                 # Here we have already asserted that the beam is a power beam and
                 # has only one polarization, so we just evaluate that one.
-                interp_beam = np.sqrt(interp_beam[0, 0, 0, 0, :])
+                if spw_axis_present:
+                    interp_beam = np.sqrt(interp_beam[0, 0, 0, 0, :])
+                else:
+                    interp_beam = np.sqrt(interp_beam[0, 0, 0, :])
 
             A_s[:, :, i] = interp_beam
 


### PR DESCRIPTION
This is a simple fix in a beam fitting function to address incompatibility with pyuvsim >= 1.25 and UVBeam future_array_shapes. Basically it is about whether or not there is a spectral window (spw) axis in the returned beam interpolation when the beam.interp method is used, and then indexes the interp result appropriately. 

I wrote a utility function that first checks whether the passed beam object is an AnalyticBeam object or a UVBeam object. Then it determines whether the spw axis is present. It raises a ValueError raise if the beam object is not one of these objects.

This is used in two different places: once in vis_simulator, and in a fitting function in beam_sampler. It should be fixed in both places now. Assumes pyuvsim >= 1.25.