### PR TITLE
removed python 3.10 and added 3.12 for tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.10 is incompatible with the package dependencies. The python package test have been updated to  python 3.11 and  python 3.12 instead.